### PR TITLE
Add a convenient integration of comath for operator overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,9 @@ zig build docs
 python -m http.server 8000 -d zig-out/docs
 open "http://localhost:8000"
 ```
+
+## Bump dependencies
+
+```shell
+zig fetch --save git+https://github.com/InKryption/comath#main
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ const units = @import("unitz").quantities(f32);
 const m = units.meter;
 const s = units.second;
 const kt = units.knot;
-const @"km/h" = units.kilometer_per_hour;
+const @"km/h" = unitz.evalQuantity(f32, "km / h", .{});
 
 fn aircraft_speed(distance: m, duration: s) kt {
 	const speed = distance.div(duration); // value is in m/s
@@ -47,45 +47,69 @@ foo.zig:29:35: note: called from here
 
 No conversion is done implicitly, the value stored in memory is exactly the one provided to the constructor.
 
-## Advanced usage
+## Defining your own units
 
-You can define your own units:
+This library does not provide all variations of standard units: meter and hour are provided, but kilometer and kilometer per hour is not. Instead, you can define any unit you want from its definition, using prefixes if needed:
+
+```zig
+const nanosecond = unitz.evalQuantity(f32, "ns", .{});
+const @"kg/m3" = unitz.evalQuantity(f32, "kg / m^3", .{});
+const kilowatthour = unitz.evalQuantity(f32, "kW * h", .{});
+const Cal = unitz.evalQuantity(f32, "kcal", .{}); // large calorie
+```
+
+## Simple example
+
+```zig
+const std = @import("std");
+const unitz = @import("unitz");
+const q = unitz.quantities(f32);
+
+const m = q.meter;
+const kg = q.kilogram;
+const lb = q.pound;
+const cm = unitz.evalQuantity(f32, "cm", .{});
+const @"kg/m²" = unitz.evalQuantity(f32, "kg / m^2", .{});
+
+fn body_mass_index(height: m, weight: kg) @"kg/m²" {
+	return weight.div(height.pow(2));
+}
+
+pub fn main() void {
+	const height = cm.init(162);
+	const weight = lb.init(124);
+	const bmi = body_mass_index(height.to(m), weight.to(kg));
+	std.debug.print("BMI: {}", .{bmi.val()});
+}
+```
+
+## Advanced example
 
 ```zig
 const unitz = @import("unitz");
-const Quantity = unitz.Quantity;
 
-const my_units = struct {
-	const u = unitz.units; // here we use the abstract units, that don't store a value
-	const ft = u.foot;
-	const lb = u.pound;
-	const s = u.second;
-	const N = u.newton;
-
-	const pound_force = ft.mul(lb).div(s.pow(2)).scale(32.174_049);
-	const pound_force_seconds = pound_force.mul(s);
-	const newton_seconds = N.mul(s);
-	const microsecond = s.prefix(.micro);
-};
-
-// We can now create quantities, that is a value expressed relatively to its unit
-const lbf = Quantity(my_units.pound_force, f32);
-const @"lbf.s" = Quantity(my_units.pound_force_seconds, f32);
-const @"N.s" = Quantity(my_units.newton_seconds, f32);
-const @"μs" = Quantity(my_units.microsecond, f32);
-
+const slug = unitz.evalUnit("32.174_049 * lb", .{});
+const lbf = unitz.evalQuantity(f32, "ft * slug / s^2", .{ .slug = slug });
+const @"lbf.s" = unitz.evalQuantity(f32, "lbf * s", .{ .lbf = lbf.unit });
+const @"N.s" = unitz.evalQuantity(f32, "N * s", .{});
+const @"μs" = unitz.evalQuantity(f32, "us", .{});
 
 fn compute_impulse(force: lbf, delta: @"μs") @"lbf.s" {
-	return force.mul(delta).to(@"lbf.s"); // we need to convert from lbf.us to lbf.s, if we forget, a compilation error occurs
+    return force.mul(delta).to(@"lbf.s"); // we need to convert from lbf.us to lbf.s, if we forget, a \
+compilation error occurs
 }
 
 fn compute_trajectory(impulse: @"N.s") void {
-	// ...
+    // ...
 }
 
-const force = lbf.init(123.0);
-const delta = @"μs".init(5);
-compute_trajectory(compute_impulse(force, delta)); // compilation error ! Adding .to(@"N.s") will fix it
+pub fn main() void {
+    const force = lbf.init(123.0);
+    const delta = @"μs".init(45.0);
+
+    compute_trajectory(compute_impulse(force, delta)); // compilation error ! Adding .to(@"N.s") will \
+fix it
+}
 ```
 
 And just like that, you can avoid [crashing into the atmosphere](https://en.wikipedia.org/wiki/Mars_Climate_Orbiter#Cause_of_failure)

--- a/build.zig
+++ b/build.zig
@@ -7,11 +7,15 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule(NAME, .{
+    const comath = b.dependency("comath", .{ .target = target, .optimize = optimize }).module("comath");
+
+    const unitz = b.addModule(NAME, .{
         .root_source_file = b.path(ROOT_FILE),
         .target = target,
         .optimize = optimize,
     });
+
+    unitz.addImport("comath", comath);
 
     { // Test
         const test_step = b.step("test", "Run unit tests");
@@ -20,6 +24,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
         });
+        lib_unit_tests.root_module.addImport("comath", comath);
         const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
         test_step.dependOn(&run_lib_unit_tests.step);
     }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,6 +12,7 @@
         "build.zig",
         "build.zig.zon",
         "src/root.zig",
+        "src/evalUnit.zig",
         "README.md",
         "LICENSE",
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,12 @@
 .{
     .name = "unitz",
     .version = "0.1.0",
+    .dependencies = .{
+        .comath = .{
+            .url = "git+https://github.com/InKryption/comath?ref=main#d2dad5a16422dfc15ed1ecf3bd93f0115a4e0192",
+            .hash = "12204d9528280144364d4f511e7edf6f0f417d840ec8179fe8179dbe4c8c62ffe991",
+        },
+    },
     .minimum_zig_version = "0.13.0",
     .paths = .{
         "build.zig",

--- a/src/evalUnit.zig
+++ b/src/evalUnit.zig
@@ -208,7 +208,7 @@ test UnitzContext {
     comptime try std.testing.expectEqual(u.watt, J_per_s);
 
     const kg_per_m3 = evalUnit("kg / m^3", .{});
-    comptime try std.testing.expectEqual(u.kilogram_per_cubic_meter, kg_per_m3);
+    comptime try std.testing.expectEqual(u.kilogram.div(u.meter.pow(3)), kg_per_m3);
 
     const per_s = evalUnit("1 / s", .{});
     comptime try std.testing.expectEqual(u.hertz, per_s);

--- a/src/evalUnit.zig
+++ b/src/evalUnit.zig
@@ -1,0 +1,168 @@
+const std = @import("std");
+const comath = @import("comath");
+const unitz = @import("root.zig");
+
+const relations = .{
+    .@"+" = comath.relation(.left, 1),
+    .@"-" = comath.relation(.left, 1),
+
+    .@"*" = comath.relation(.left, 2),
+    .@"/" = comath.relation(.left, 2),
+
+    .@"^" = comath.relation(.left, 3),
+};
+
+const BinaryOperators = std.meta.FieldEnum(@TypeOf(relations));
+
+pub inline fn unitzContext(identifiers: anytype) UnitzContext(@TypeOf(identifiers)) {
+    return .{ .identifiers = identifiers };
+}
+
+pub fn UnitzContext(comptime _builtin_identifiers: type) type {
+    return struct {
+        const Self = @This();
+        const U = unitz.units;
+        const builtin_identifiers = _builtin_identifiers;
+
+        identifiers: Self.builtin_identifiers,
+
+        /// Should return `true` for any string of symbols corresponding to a recognized binary operator.
+        pub inline fn matchBinOp(comptime str: []const u8) bool {
+            return @hasField(BinaryOperators, str);
+        }
+
+        /// Returns the order of the binary operators `lhs` and `rhs`, where `matchBinOp(lhs) = true`, and
+        /// `matchBinOp(rhs) = true`.
+        pub inline fn orderBinOp(comptime lhs: []const u8, comptime rhs: []const u8) ?comath.Order {
+            if (!@hasField(BinaryOperators, lhs)) return null;
+            if (!@hasField(BinaryOperators, rhs)) return null;
+            return @field(relations, lhs).order(@field(relations, rhs));
+        }
+
+        /// Determines the value and type of number literals.
+        pub fn EvalNumberLiteral(comptime src: []const u8) type {
+            return switch (std.zig.parseNumberLiteral(src)) {
+                .int => comptime_int,
+                .float => comptime_float,
+                else => noreturn,
+            };
+        }
+        pub fn evalNumberLiteral(comptime src: []const u8) EvalNumberLiteral(src) {
+            return switch (std.zig.parseNumberLiteral(src)) {
+                .int => |val| val,
+                .big_int => @compileError("Big Ints are not supported yet"),
+                .float => std.fmt.parseFloat(f128, src) catch |err| @compileError(@errorName(err)),
+                .failure => |failure| @compileError(switch (failure) {
+                    .leading_zero => "Invalid leading zeroes in '" ++ src ++ "'",
+                    .digit_after_base => "Expected digit after base in '" ++ src ++ "'",
+                    .upper_case_base, .invalid_float_base => "Invalid base in '" ++ src ++ "'",
+                    .repeated_underscore, .invalid_underscore_after_special => "Invalid underscore in '" ++ src ++ "'",
+                    .invalid_digit => |info| std.fmt.comptimePrint(
+                        "Invalid digit '{c}' in '{s}' with base '{s}'",
+                        .{ src[info.i], src, @tagName(info.base) },
+                    ),
+                    .invalid_digit_exponent => |exp_idx| std.fmt.comptimePrint(
+                        "Invalid exponent '{c}' in '{s}'",
+                        .{ src[exp_idx], src },
+                    ),
+                    .duplicate_period => "Duplicate periods in '" ++ src ++ "'",
+                    .duplicate_exponent => "Duplicate exponents in '" ++ src ++ "'",
+                    .exponent_after_underscore => "Exponent after underscore in '" ++ src ++ "'",
+                    .special_after_underscore => |spec_idx| std.fmt.comptimePrint(
+                        "Invalid '{c}' after underscore in '{s}'",
+                        .{ src[spec_idx], src },
+                    ),
+                    .trailing_special,
+                    .trailing_underscore,
+                    .invalid_character,
+                    .invalid_exponent_sign,
+                    => |err_idx| std.fmt.comptimePrint(
+                        "Invalid '{c}' in '{s}'",
+                        .{ src[err_idx], src },
+                    ),
+                }),
+            };
+        }
+
+        /// Determines the value and type of identifiers, overriding those which would otherwise be
+        /// determined via the `inputs` struct. `EvalIdent` returning `noreturn` causes
+        /// `eval` to instead look for the identifier in the `inputs` struct.
+        pub fn EvalIdent(comptime ident: []const u8) type {
+            if (@hasField(Self.builtin_identifiers, ident))
+                return type;
+            return noreturn;
+        }
+
+        pub fn evalIdent(ctx: Self, comptime ident: []const u8) !EvalIdent(ident) {
+            if (@hasField(Self.builtin_identifiers, ident))
+                return @field(ctx.identifiers, ident);
+            comptime unreachable;
+        }
+
+        /// Corresponds to `lhs op rhs`
+        /// In most contexts, it should be sufficient to assume `@hasField(BinOp, op)`.
+        pub fn EvalBinOp(comptime Lhs: type, comptime op: []const u8, comptime Rhs: type) type {
+            _ = Lhs;
+            _ = op;
+            _ = Rhs;
+            return type;
+        }
+        pub fn evalBinOp(ctx: @This(), lhs: anytype, comptime op: []const u8, rhs: anytype) !EvalBinOp(@TypeOf(lhs), op, @TypeOf(rhs)) {
+            _ = ctx;
+
+            const L = switch (@TypeOf(lhs)) {
+                comptime_int, comptime_float => U.one.scale(lhs),
+                else => lhs,
+            };
+
+            return switch (@field(BinaryOperators, op)) {
+                .@"+" => L.add(rhs),
+                .@"-" => L.sub(rhs),
+                .@"*" => L.mul(rhs),
+                .@"/" => L.div(rhs),
+                .@"^" => L.pow(rhs),
+            };
+        }
+    };
+}
+
+pub inline fn evalUnitSI(comptime expr: []const u8) !type {
+    const u = unitz.units;
+    const ctx = unitzContext(.{
+        .m = u.meter,
+        .s = u.second,
+        .kg = u.kilogram,
+        .A = u.ampere,
+        .K = u.kelvin,
+
+        .Hz = u.hertz,
+        .N = u.newton,
+        .Pa = u.pascal,
+        .J = u.joule,
+        .W = u.watt,
+        .C = u.coulomb,
+        .V = u.volt,
+        .F = u.farad,
+        .Ohm = u.ohm,
+        .S = u.siemens,
+        .Wb = u.weber,
+        .T = u.tesla,
+        .H = u.henry,
+    });
+    return comath.eval(expr, ctx, .{});
+}
+
+test UnitzContext {
+    //comptime try std.testing.expectEqual(f128, comptime_float);
+
+    const u = unitz.units;
+
+    const J_per_s = try evalUnitSI("J / s");
+    comptime try std.testing.expectEqual(u.watt, J_per_s);
+
+    const kg_per_m3 = try evalUnitSI("kg / m^3");
+    comptime try std.testing.expectEqual(u.kilogram_per_cubic_meter, kg_per_m3);
+
+    const per_s = try evalUnitSI("1 / s");
+    comptime try std.testing.expectEqual(u.hertz, per_s);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -116,6 +116,7 @@ pub fn Unit(
             return Self.scale(prefixFactor(_prefix));
         }
 
+        /// Two units are compatible if they measure the same kind of dimension
         pub fn is_compatible(other: type) bool {
             return Self.meter == other.meter and Self.second == other.second and Self.kilogram == other.kilogram and Self.ampere == other.ampere and Self.kelvin == other.kelvin;
         }
@@ -138,16 +139,12 @@ pub const units = struct {
     pub const gram = kilogram.scale(1e-3);
     /// Metric ton
     pub const tonne = kilogram.scale(1e3);
+    pub const liter = meter.prefix(.deci).pow(3);
 
     pub const minute = second.scale(60);
     pub const hour = minute.scale(60);
     pub const day = hour.scale(24);
     pub const week = day.scale(7);
-
-    pub const square_meter = meter.pow(2);
-    pub const cubic_meter = meter.pow(3);
-    pub const kilogram_per_cubic_meter = kilogram.div(cubic_meter);
-    pub const liter = meter.prefix(.deci).pow(3);
 
     pub const hertz = one.div(second);
     pub const newton = kilogram.mul(meter).div(second.pow(2));
@@ -174,10 +171,7 @@ pub const units = struct {
     pub const ounce = dram.scale(16.0);
     pub const pound = ounce.scale(16.0);
 
-    pub const meter_per_second = meter.div(second);
-    pub const kilometer_per_hour = meter.prefix(.kilo).div(hour);
     pub const knot = nautical_mile.div(hour);
-
     pub const imperial_horsepower = watt.scale(745.699_871_582_270_22);
     pub const gauss = tesla.scale(1e-4);
     pub const calorie = joule.scale(4.184);
@@ -197,6 +191,8 @@ test Unit {
 
     try comptime std.testing.expectEqual(u.meter.scale(0.3048), u.foot);
     try comptime std.testing.expectEqual(u.meter.scale(0.9144), u.yard);
+
+    try comptime std.testing.expectEqual(u.meter.scale(1000), u.meter.prefix(.kilo));
 }
 
 /// A quantity is a measure expressed relatively to its unit
@@ -237,7 +233,7 @@ pub fn Quantity(comptime _unit: type, comptime T: type) type {
         }
 
         pub fn pow(self: Self, power: comptime_int) Quantity(Self.unit.pow(power), T) {
-            return .{ .value = std.math.pow(self.value, power) };
+            return .{ .value = std.math.pow(T, self.value, power) };
         }
 
         pub inline fn to(self: Self, dest: type) dest {
@@ -272,14 +268,12 @@ pub fn quantities(T: type) type {
         pub const gram = Quantity(u.gram, T);
         /// Metric ton
         pub const tonne = Quantity(u.tonne, T);
+        pub const liter = Quantity(u.liter, T);
 
         pub const minute = Quantity(u.minute, T);
         pub const hour = Quantity(u.hour, T);
         pub const day = Quantity(u.day, T);
-
-        pub const square_meter = Quantity(u.square_meter, T);
-        pub const cubic_meter = Quantity(u.cubic_meter, T);
-        pub const kilogram_per_cubic_meter = Quantity(u.kilogram_per_cubic_meter, T);
+        pub const week = Quantity(u.week, T);
 
         pub const hertz = Quantity(u.hertz, T);
         pub const newton = Quantity(u.newton, T);
@@ -300,16 +294,16 @@ pub fn quantities(T: type) type {
         pub const yard = Quantity(u.yard, T);
         pub const mile = Quantity(u.mile, T);
         pub const nautical_mile = Quantity(u.nautical_mile, T);
+        pub const furlong = Quantity(u.furlong, T);
 
         pub const dram = Quantity(u.dram, T);
         pub const ounce = Quantity(u.ounce, T);
         pub const pound = Quantity(u.pound, T);
 
-        pub const meter_per_second = Quantity(u.meter_per_second, T);
-        pub const kilometer_per_hour = Quantity(u.kilometer_per_hour, T);
         pub const knot = Quantity(u.knot, T);
-
         pub const imperial_horsepower = Quantity(u.imperial_horsepower, T);
+        pub const gauss = Quantity(u.gauss, T);
+        pub const calorie = Quantity(u.calorie, T);
     };
 }
 
@@ -317,8 +311,8 @@ test Quantity {
     const u = quantities(f32);
     const m = u.meter;
     const s = u.second;
-    const @"m/s" = u.meter_per_second;
-    const m2 = u.square_meter;
+    const @"m/s" = Quantity(u.meter.unit.div(u.second.unit), f32);
+    const m2 = Quantity(u.meter.unit.pow(2), f32);
     const lb = u.pound;
     const N = u.newton;
     const W = u.watt;

--- a/src/root.zig
+++ b/src/root.zig
@@ -211,6 +211,10 @@ pub fn Quantity(comptime _unit: type, comptime T: type) type {
             return self.value;
         }
 
+        pub fn negate(self: Self) Self {
+            return Self.init(-self.value);
+        }
+
         pub fn add(self: Self, other: Self) Self {
             return Self.init(self.value + other.value);
         }
@@ -225,6 +229,10 @@ pub fn Quantity(comptime _unit: type, comptime T: type) type {
 
         pub fn div(self: Self, other: anytype) Quantity(Self.unit.div(@TypeOf(other).unit), T) {
             return .{ .value = self.value / other.value };
+        }
+
+        pub fn pow(self: Self, power: comptime_int) Quantity(Self.unit.pow(power), T) {
+            return .{ .value = std.math.pow(self.value, power) };
         }
 
         pub inline fn to(self: Self, dest: type) dest {
@@ -245,6 +253,7 @@ pub fn Quantity(comptime _unit: type, comptime T: type) type {
 pub fn quantities(T: type) type {
     const u = units;
     return struct {
+        pub const unitless = Quantity(u.one, T);
         pub const radian = Quantity(u.radian, T);
         pub const turn = Quantity(u.turn, T);
         pub const arcdegree = Quantity(u.arcdegree, T);
@@ -357,4 +366,10 @@ test Quantity {
 
     try std.testing.expectApproxEqAbs(33_000.0, one_hp.to_val(@"ft.lbf/min"), 0.001);
     try std.testing.expectApproxEqAbs(745.699_871_582, one_hp.to_val(W), 0.000_1);
+}
+
+pub const eval = @import("evalUnit.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(@This());
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -373,7 +373,10 @@ test Quantity {
     try std.testing.expectApproxEqAbs(745.699_871_582, one_hp.to_val(W), 0.000_1);
 }
 
-pub const eval = @import("evalUnit.zig");
+const eval_unit = @import("evalUnit.zig");
+
+pub const evalUnit = eval_unit.evalUnit;
+pub const evalQuantity = eval_unit.evalQuantity;
 
 test {
     std.testing.refAllDeclsRecursive(@This());

--- a/src/root.zig
+++ b/src/root.zig
@@ -142,10 +142,12 @@ pub const units = struct {
     pub const minute = second.scale(60);
     pub const hour = minute.scale(60);
     pub const day = hour.scale(24);
+    pub const week = day.scale(7);
 
     pub const square_meter = meter.pow(2);
     pub const cubic_meter = meter.pow(3);
     pub const kilogram_per_cubic_meter = kilogram.div(cubic_meter);
+    pub const liter = meter.prefix(.deci).pow(3);
 
     pub const hertz = one.div(second);
     pub const newton = kilogram.mul(meter).div(second.pow(2));
@@ -166,6 +168,7 @@ pub const units = struct {
     pub const yard = foot.scale(3);
     pub const mile = yard.scale(1_760);
     pub const nautical_mile = meter.scale(1_852);
+    pub const furlong = yard.scale(220);
 
     pub const dram = gram.scale(1.771_845_195_312_5);
     pub const ounce = dram.scale(16.0);
@@ -176,6 +179,8 @@ pub const units = struct {
     pub const knot = nautical_mile.div(hour);
 
     pub const imperial_horsepower = watt.scale(745.699_871_582_270_22);
+    pub const gauss = tesla.scale(1e-4);
+    pub const calorie = joule.scale(4.184);
 };
 
 test Unit {


### PR DESCRIPTION
Possible Interface:
```zig
const @"m/s" = unitz.evalUnit(f32, "m/s");
```
Or:
```zig
const @"m/s" = unitz.Quantity(unitz.evalUnit("m/s"), f32);
```

Then:
```zig
const drag = unitz.eval("A * p * u^2 * c / 2", .{.A = area, .p = density, .u = speed, c = coef});
```