### PR TITLE
Improve public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,12 @@ Achieve compile-time unit correctness and avoid runtime surprises.
 Use units as types, to document your functions, and convert to units of the same dimension:
 
 ```zig
-const unitz = @import("unitz");
-const units = unitz.quantities(f32);
+const units = @import("unitz").quantities(f32);
 
 const m = units.meter;
 const s = units.second;
 const kt = units.knot;
-const @"km/h" = unitz.evalQuantity(f32, "km / h", .{});
+const @"km/h" = units.eval("km / h", .{});
 
 fn aircraft_speed(distance: m, duration: s) kt {
 	const speed = distance.div(duration); // value is in m/s
@@ -66,10 +65,10 @@ No conversion is done implicitly, the value stored in memory is exactly the one 
 This library does not provide all variations of standard units: meter and hour are provided, but kilometer and kilometer per hour is not. Instead, you can define any unit you want from its definition, using prefixes if needed:
 
 ```zig
-const nanosecond = unitz.evalQuantity(f32, "ns", .{});
-const @"kg/m3" = unitz.evalQuantity(f32, "kg / m^3", .{});
-const kilowatthour = unitz.evalQuantity(f32, "kW * h", .{});
-const Cal = unitz.evalQuantity(f32, "kcal", .{}); // large calorie
+const nanosecond = units.eval("ns", .{});
+const @"kg/m3" = units.eval("kg / m^3", .{});
+const kilowatthour = units.eval("kW * h", .{});
+const Cal = units.eval("kcal", .{}); // large calorie
 ```
 
 ## Simple example
@@ -82,8 +81,8 @@ const q = unitz.quantities(f32);
 const m = q.meter;
 const kg = q.kilogram;
 const lb = q.pound;
-const cm = unitz.evalQuantity(f32, "cm", .{});
-const @"kg/m²" = unitz.evalQuantity(f32, "kg / m^2", .{});
+const cm = q.eval("cm", .{});
+const @"kg/m²" = q.eval("kg / m^2", .{});
 
 fn body_mass_index(height: m, weight: kg) @"kg/m²" {
 	return weight.div(height.pow(2));
@@ -101,13 +100,13 @@ pub fn main() void {
 
 We redefine slug and pound-force to show how it can be done
 ```zig
-const unitz = @import("unitz");
+const u = @import("unitz").quantities(f32);
 
-const slug = unitz.evalUnit("32.174_049 * lb", .{});
-const lbf = unitz.evalQuantity(f32, "ft * my_slug / s^2", .{ .my_slug = slug });
-const @"lbf.s" = unitz.evalQuantity(f32, "my_lbf * s", .{ .my_lbf = lbf.unit });
-const @"N.s" = unitz.evalQuantity(f32, "N * s", .{});
-const @"μs" = unitz.evalQuantity(f32, "us", .{});
+const slug = u.eval("32.174_049 * lb", .{});
+const lbf = u.eval("ft * my_slug / s^2", .{ .my_slug = slug.unit });
+const @"lbf.s" = u.eval("my_lbf * s", .{ .my_lbf = lbf.unit });
+const @"N.s" = u.eval("N * s", .{});
+const @"μs" = u.eval("us", .{});
 
 fn compute_impulse(force: lbf, delta: @"μs") @"lbf.s" {
     return .from(force.mul(delta)); // The .from converts to the target unit

--- a/samples/error_div_invalid_argument.zig
+++ b/samples/error_div_invalid_argument.zig
@@ -1,7 +1,6 @@
 // Dividing a Quantity by a raw scalar instead of another Quantity.
 
-const unitz = @import("unitz");
-const u = unitz.quantities(f32);
+const u = @import("unitz").quantities(f32);
 
 pub fn main() void {
     const distance: u.meter = .init(10);
@@ -10,4 +9,4 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:19:9: error: div() expects a Quantity, got 'comptime_int' (use scale() for a plain scalar)
+//   src/quantity.zig:20:9: error: div() expects a Quantity, got 'comptime_int' (use scale() for a plain scalar)

--- a/samples/error_from_incompatible_units.zig
+++ b/samples/error_from_incompatible_units.zig
@@ -1,7 +1,6 @@
 // Calling .from() with a Quantity whose unit has a different dimension.
 
-const unitz = @import("unitz");
-const units = unitz.quantities(f32);
+const units = @import("unitz").quantities(f32);
 
 const J = units.joule;
 const hp = units.imperial_horsepower;
@@ -13,8 +12,8 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:84:60: error: Units are only interconvertible if they measure the same kind of dimension
-//   src/quantity.zig:46:28: note: called inline here
+//   src/quantity.zig:85:60: error: Units are only interconvertible if they measure the same kind of dimension
+//   src/quantity.zig:47:28: note: called inline here
 //       return value.to(Self);
-//   error_from_incompatible_units.zig:11:28: note: called inline here
+//   error_from_incompatible_units.zig:10:28: note: called inline here
 //       const energy: J = .from(engine_power);

--- a/samples/error_from_invalid_source.zig
+++ b/samples/error_from_invalid_source.zig
@@ -1,7 +1,6 @@
 // Passing a raw value (not a Quantity) to .from().
 
-const unitz = @import("unitz");
-const u = unitz.quantities(f32);
+const u = @import("unitz").quantities(f32);
 
 pub fn main() void {
     const m: u.meter = .from(1.0);
@@ -9,6 +8,6 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:43:17: error: from() expects a Quantity, got 'comptime_float'
-//   error_from_invalid_source.zig:7:29: note: called inline here
+//   src/quantity.zig:44:17: error: from() expects a Quantity, got 'comptime_float'
+//   error_from_invalid_source.zig:6:29: note: called inline here
 //       const m: u.meter = .from(1.0);

--- a/samples/error_from_storage_mismatch.zig
+++ b/samples/error_from_storage_mismatch.zig
@@ -11,6 +11,6 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:45:17: error: from() requires the source quantity to share the same storage type; convert it first with floatCast()
+//   src/quantity.zig:46:17: error: from() requires the source quantity to share the same storage type; convert it first with floatCast()
 //   error_from_storage_mismatch.zig:9:31: note: called inline here
 //       const b: q64.meter = .from(a);

--- a/samples/error_mul_invalid_argument.zig
+++ b/samples/error_mul_invalid_argument.zig
@@ -1,7 +1,6 @@
 // Multiplying a Quantity by a raw scalar instead of another Quantity.
 
-const unitz = @import("unitz");
-const u = unitz.quantities(f32);
+const u = @import("unitz").quantities(f32);
 
 pub fn main() void {
     const distance: u.meter = .init(1);
@@ -10,4 +9,4 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:19:9: error: mul() expects a Quantity, got 'comptime_int' (use scale() for a plain scalar)
+//   src/quantity.zig:20:9: error: mul() expects a Quantity, got 'comptime_int' (use scale() for a plain scalar)

--- a/samples/error_sqrt_odd_dimension.zig
+++ b/samples/error_sqrt_odd_dimension.zig
@@ -1,7 +1,6 @@
 // Taking the square root of a unit whose dimension exponents are not all even.
 
-const unitz = @import("unitz");
-const u = unitz.quantities(f32);
+const u = @import("unitz").quantities(f32);
 
 pub fn main() void {
     const length: u.meter = .init(4);
@@ -10,4 +9,4 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/unit.zig:100:17: error: Unit.sqrt requires every dimension exponent to be even
+//   src/unit.zig:101:17: error: Unit.sqrt requires every dimension exponent to be even

--- a/samples/error_to_incompatible_units.zig
+++ b/samples/error_to_incompatible_units.zig
@@ -1,7 +1,6 @@
 // Calling .to() between units of different dimensions.
 
-const unitz = @import("unitz");
-const units = unitz.quantities(f32);
+const units = @import("unitz").quantities(f32);
 
 const J = units.joule;
 const hp = units.imperial_horsepower;
@@ -13,4 +12,4 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:84:60: error: Units are only interconvertible if they measure the same kind of dimension
+//   src/quantity.zig:85:60: error: Units are only interconvertible if they measure the same kind of dimension

--- a/samples/error_to_invalid_destination.zig
+++ b/samples/error_to_invalid_destination.zig
@@ -1,7 +1,6 @@
 // Passing a non-Quantity type as the destination of .to().
 
-const unitz = @import("unitz");
-const u = unitz.quantities(f32);
+const u = @import("unitz").quantities(f32);
 
 pub fn main() void {
     const distance: u.meter = .init(1);
@@ -10,4 +9,4 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:79:17: error: to() expects a Quantity type, got 'f32'
+//   src/quantity.zig:80:17: error: to() expects a Quantity type, got 'f32'

--- a/samples/error_to_storage_mismatch.zig
+++ b/samples/error_to_storage_mismatch.zig
@@ -11,4 +11,4 @@ pub fn main() void {
 }
 
 // Expected error:
-//   src/quantity.zig:81:17: error: to() requires the destination quantity to share the same storage type; convert it first with floatCast()
+//   src/quantity.zig:82:17: error: to() requires the destination quantity to share the same storage type; convert it first with floatCast()

--- a/samples/example_aircraft_speed.zig
+++ b/samples/example_aircraft_speed.zig
@@ -2,13 +2,12 @@
 // return the speed converted to knots, and print every form along the way.
 
 const std = @import("std");
-const unitz = @import("unitz");
-const units = unitz.quantities(f32);
+const units = @import("unitz").quantities(f32);
 
 const m = units.meter;
 const s = units.second;
 const kt = units.knot;
-const @"km/h" = unitz.evalQuantity(f32, "km / h", .{});
+const @"km/h" = units.eval("km / h", .{});
 
 fn aircraft_speed(distance: m, duration: s) kt {
     const speed = distance.div(duration); // value is in m/s

--- a/samples/example_body_mass_index.zig
+++ b/samples/example_body_mass_index.zig
@@ -2,14 +2,13 @@
 // length and mass units, return the BMI in kg/m².
 
 const std = @import("std");
-const unitz = @import("unitz");
-const q = unitz.quantities(f32);
+const q = @import("unitz").quantities(f32);
 
 const m = q.meter;
 const kg = q.kilogram;
 const lb = q.pound;
-const cm = unitz.evalQuantity(f32, "cm", .{});
-const @"kg/m²" = unitz.evalQuantity(f32, "kg / m^2", .{});
+const cm = q.eval("cm", .{});
+const @"kg/m²" = q.eval("kg / m^2", .{});
 
 fn body_mass_index(height: m, weight: kg) @"kg/m²" {
     return weight.div(height.pow(2));

--- a/samples/example_impulse.zig
+++ b/samples/example_impulse.zig
@@ -3,13 +3,13 @@
 // before passing it to a function that expects metric units.
 
 const std = @import("std");
-const unitz = @import("unitz");
+const u = @import("unitz").quantities(f32);
 
-const slug = unitz.evalUnit("32.174_049 * lb", .{});
-const lbf = unitz.evalQuantity(f32, "ft * my_slug / s^2", .{ .my_slug = slug });
-const @"lbf.s" = unitz.evalQuantity(f32, "my_lbf * s", .{ .my_lbf = lbf.unit });
-const @"N.s" = unitz.evalQuantity(f32, "N * s", .{});
-const @"μs" = unitz.evalQuantity(f32, "us", .{});
+const slug = u.eval("32.174_049 * lb", .{});
+const lbf = u.eval("ft * my_slug / s^2", .{ .my_slug = slug.unit });
+const @"lbf.s" = u.eval("my_lbf * s", .{ .my_lbf = lbf.unit });
+const @"N.s" = u.eval("N * s", .{});
+const @"μs" = u.eval("us", .{});
 
 fn compute_impulse(force: lbf, delta: @"μs") @"lbf.s" {
     return .from(force.mul(delta)); // The .from converts to the target unit

--- a/src/quantity.zig
+++ b/src/quantity.zig
@@ -119,12 +119,23 @@ fn Quantities(T: type) type {
         }
     };
 
-    const N = decls.len + 1;
+    // The `units` namespace also exposes non-type decls (e.g. its own `eval`).
+    // Skip them — only Unit types map to Quantity fields.
+    const N = blk: {
+        var n: usize = 1; // +1 for our own `eval` helper
+        for (decls) |decl| {
+            if (@TypeOf(@field(unit_namespace.units, decl.name)) == type) n += 1;
+        }
+        break :blk n;
+    };
+
     var field_names: [N][]const u8 = undefined;
     var field_types: [N]type = undefined;
     var field_attrs: [N]std.builtin.Type.StructField.Attributes = undefined;
 
-    for (decls, 0..) |decl, i| {
+    var i: usize = 0;
+    for (decls) |decl| {
+        if (@TypeOf(@field(unit_namespace.units, decl.name)) != type) continue;
         field_names[i] = decl.name;
         field_types[i] = type;
         field_attrs[i] = .{
@@ -132,11 +143,12 @@ fn Quantities(T: type) type {
             .@"align" = @alignOf(T),
             .default_value_ptr = &Quantity(@field(unit_namespace.units, decl.name), T),
         };
+        i += 1;
     }
 
-    field_names[decls.len] = "eval";
-    field_types[decls.len] = @TypeOf(Helpers.eval);
-    field_attrs[decls.len] = .{
+    field_names[i] = "eval";
+    field_types[i] = @TypeOf(Helpers.eval);
+    field_attrs[i] = .{
         .@"comptime" = true,
         .default_value_ptr = &Helpers.eval,
     };

--- a/src/quantity.zig
+++ b/src/quantity.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const unit_namespace = @import("unit.zig");
+const eval_namespace = @import("eval.zig");
 
 /// True iff `T` is a `Quantity` instantiation.
 fn isQuantity(comptime T: type) bool {
@@ -104,25 +105,67 @@ pub fn Quantity(comptime _unit: type, comptime T: type) type {
     };
 }
 
-/// Generate default quantities from default units
+/// Generate default quantities from default units, plus a comptime `eval`
+/// helper bound to the given storage type.
 fn Quantities(T: type) type {
     const decls = @typeInfo(unit_namespace.units).@"struct".decls;
-    var field_names: [decls.len][]const u8 = undefined;
-    var field_attrs: [decls.len]std.builtin.Type.StructField.Attributes = undefined;
-    for (decls, &field_names, &field_attrs) |decl, *name, *attrs| {
-        name.* = decl.name;
-        attrs.* = .{
+
+    const Helpers = struct {
+        /// Build a Quantity type from a unit expression, with the storage `T`
+        /// captured from the surrounding `Quantities(T)`. Pass `.{}` for `inputs`
+        /// when the expression contains no user-defined identifiers.
+        fn eval(comptime expr: []const u8, inputs: anytype) type {
+            return Quantity(eval_namespace.evalUnit(expr, inputs), T);
+        }
+    };
+
+    const N = decls.len + 1;
+    var field_names: [N][]const u8 = undefined;
+    var field_types: [N]type = undefined;
+    var field_attrs: [N]std.builtin.Type.StructField.Attributes = undefined;
+
+    for (decls, 0..) |decl, i| {
+        field_names[i] = decl.name;
+        field_types[i] = type;
+        field_attrs[i] = .{
             .@"comptime" = true,
             .@"align" = @alignOf(T),
             .default_value_ptr = &Quantity(@field(unit_namespace.units, decl.name), T),
         };
     }
-    return @Struct(.auto, null, &field_names, &@splat(type), &field_attrs);
+
+    field_names[decls.len] = "eval";
+    field_types[decls.len] = @TypeOf(Helpers.eval);
+    field_attrs[decls.len] = .{
+        .@"comptime" = true,
+        .default_value_ptr = &Helpers.eval,
+    };
+
+    return @Struct(.auto, null, &field_names, &field_types, &field_attrs);
 }
 
 /// To see the list of quantities, refer to the list of units in the `units` namespace
 pub fn quantities(T: type) Quantities(T) {
     return .{};
+}
+
+test "quantities(T).eval shorthand" {
+    const u = quantities(f32);
+
+    // Common case: no custom identifiers
+    const kilowatthour = u.eval("kW * h", .{});
+    try comptime std.testing.expectEqual(eval_namespace.evalQuantity(f32, "kW * h", .{}), kilowatthour);
+
+    const energy: kilowatthour = .init(2.5);
+    try std.testing.expectEqual(2.5, energy.val());
+
+    // Advanced case: pass user-defined identifiers
+    const slug = eval_namespace.evalUnit("32.174_049 * lb", .{});
+    const lbf = u.eval("ft * my_slug / s^2", .{ .my_slug = slug });
+    try comptime std.testing.expectEqual(
+        eval_namespace.evalQuantity(f32, "ft * my_slug / s^2", .{ .my_slug = slug }),
+        lbf,
+    );
 }
 
 test Quantity {

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,8 +9,6 @@ pub const Unit = unit.Unit;
 pub const units = unit.units;
 pub const Quantity = quantity.Quantity;
 pub const quantities = quantity.quantities;
-pub const evalUnit = eval.evalUnit;
-pub const evalQuantity = eval.evalQuantity;
 
 test {
     std.testing.refAllDecls(@This());

--- a/src/root.zig
+++ b/src/root.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 
 const unit = @import("unit.zig");
 const quantity = @import("quantity.zig");
-const eval = @import("eval.zig");
 
 pub const Prefix = @import("prefix.zig").Prefix;
 pub const Unit = unit.Unit;
@@ -11,5 +10,6 @@ pub const Quantity = quantity.Quantity;
 pub const quantities = quantity.quantities;
 
 test {
+    _ = @import("eval.zig");
     std.testing.refAllDecls(@This());
 }

--- a/src/unit.zig
+++ b/src/unit.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const prefix_namespace = @import("prefix.zig");
+const eval_namespace = @import("eval.zig");
 
 const Prefix = prefix_namespace.Prefix;
 const prefixFactor = prefix_namespace.prefixFactor;
@@ -244,6 +245,12 @@ pub const units = struct {
     pub const weber = joule.div(ampere);
     /// H
     pub const henry = weber.div(second);
+
+    /// Build a Unit type from an expression like `"kg / m^3"`. Pass `.{}`
+    /// for `inputs` when the expression contains no user-defined identifiers.
+    pub fn eval(comptime expr: []const u8, inputs: anytype) type {
+        return eval_namespace.evalUnit(expr, inputs);
+    }
 };
 
 test Unit {
@@ -264,4 +271,9 @@ test Unit {
     try comptime std.testing.expectEqual(u.meter.scale(1000), u.meter.prefix(.kilo));
 
     try comptime std.testing.expectEqual(u.joule.div(u.kilogram).sqrt(), u.meter.div(u.second));
+}
+
+test "units.eval shorthand" {
+    try comptime std.testing.expectEqual(units.meter.div(units.second), units.eval("m / s", .{}));
+    try comptime std.testing.expectEqual(units.joule.prefix(.mega).scale(3.6), units.eval("kW * h", .{}));
 }


### PR DESCRIPTION
This is a breaking change

Place an eval function in the `units` and `quantities(T)` namespaces, as a replacement for `evalUnit` and `evalQuantity`

users no longer have to keep the unitz namespace and can just use `const u = @import("unitz").quantities(f32)` for example